### PR TITLE
Fix typo on a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following registries are created with this plugin:
 
 ### Icon Generation
 
-This phase should be done using the [Item Exporter mod](https://github.com/CyclopsMC/IconExporter).
+This phase should be done using the [Icon Exporter mod](https://github.com/CyclopsMC/IconExporter).
 
 Simply create a modpack with all the mods that were downloaded in the previous step (including the Item Exporter mod),
 start a world, and run the `/iconexporter export 64` command.


### PR DESCRIPTION
The Icon Exporter mod-link is named "Item Exporter mod".